### PR TITLE
Add skip steady state option

### DIFF
--- a/src/Droplet.Core.Inp/Data/InpTableRow.cs
+++ b/src/Droplet.Core.Inp/Data/InpTableRow.cs
@@ -4,7 +4,6 @@
 
 using Droplet.Core.Inp.Entities;
 using Droplet.Core.Inp.Options;
-using System;
 using System.Collections.Generic;
 
 namespace Droplet.Core.Inp.Data

--- a/src/Droplet.Core.Inp/Data/InpTableRow.cs
+++ b/src/Droplet.Core.Inp/Data/InpTableRow.cs
@@ -90,6 +90,7 @@ namespace Droplet.Core.Inp.Data
             LinkOffsetOption.OptionName => new LinkOffsetOption(row: this, database: database),
             MinSlopeOption.OptionName => new MinSlopeOption(row: this, database: database),
             AllowPondingOption.OptionName => new AllowPondingOption(row: this, database: database),
+            SkipSteadyStateOption.OptionName => new SkipSteadyStateOption(row: this, database: database),
 
             // TODO: Add exception here
             _ => new InpOption()

--- a/src/Droplet.Core.Inp/Data/InpTableRow.cs
+++ b/src/Droplet.Core.Inp/Data/InpTableRow.cs
@@ -70,30 +70,10 @@ namespace Droplet.Core.Inp.Data
         /// and the database</returns>
         private IInpEntity InitializeEntity(IInpDatabase database) => InpTable.Name switch
         {
-            InpOption.HeaderName => GetOptionEntity(Key, database),
+            InpOption.HeaderName => InpOption.CreateFromOptionName(Key, this, database),
 
             // TODO: Add exception here
             _                    => new InpEntity()
-        };
-
-        /// <summary>
-        /// Create the option that is associated with the option name <paramref name="optionName"/>
-        /// </summary>
-        /// <param name="optionName">The name of the option that will be created</param>
-        /// <param name="database">The <see cref="IInpDatabase"/> that the option will belong to</param>
-        /// <returns>Returns: an option that is refered to by the option name that is passed</returns>
-        private InpOption GetOptionEntity(string optionName, IInpDatabase database) => optionName switch
-        {
-            FlowUnitsOption.OptionName => new FlowUnitsOption(row: this, database: database),
-            InfiltrationOption.OptionName => new InfiltrationOption(row: this, database: database),
-            FlowRoutingOption.OptionName => new FlowRoutingOption(row: this, database: database),
-            LinkOffsetOption.OptionName => new LinkOffsetOption(row: this, database: database),
-            MinSlopeOption.OptionName => new MinSlopeOption(row: this, database: database),
-            AllowPondingOption.OptionName => new AllowPondingOption(row: this, database: database),
-            SkipSteadyStateOption.OptionName => new SkipSteadyStateOption(row: this, database: database),
-
-            // TODO: Add exception here
-            _ => new InpOption()
         };
     }
 }

--- a/src/Droplet.Core.Inp/Options/InpOption.cs
+++ b/src/Droplet.Core.Inp/Options/InpOption.cs
@@ -60,15 +60,15 @@ namespace Droplet.Core.Inp.Options
         /// <returns>Returns: an option that is refered to by the <paramref name="optionName"/> that is passed</returns>
         internal static InpOption CreateFromOptionName(string optionName, IInpTableRow row, IInpDatabase database) => optionName switch
         {
-            FlowUnitsOption.OptionName => new FlowUnitsOption(row: row, database: database),
-            InfiltrationOption.OptionName => new InfiltrationOption(row: row, database: database),
-            FlowRoutingOption.OptionName => new FlowRoutingOption(row: row, database: database),
-            LinkOffsetOption.OptionName => new LinkOffsetOption(row: row, database: database),
-            MinSlopeOption.OptionName => new MinSlopeOption(row: row, database: database),
-            AllowPondingOption.OptionName => new AllowPondingOption(row: row, database: database),
-            SkipSteadyStateOption.OptionName => new SkipSteadyStateOption(row: row, database: database),
+            FlowUnitsOption.OptionName => new FlowUnitsOption(row, database),
+            InfiltrationOption.OptionName => new InfiltrationOption(row, database),
+            FlowRoutingOption.OptionName => new FlowRoutingOption(row, database),
+            LinkOffsetOption.OptionName => new LinkOffsetOption(row, database),
+            MinSlopeOption.OptionName => new MinSlopeOption(row, database),
+            AllowPondingOption.OptionName => new AllowPondingOption(row, database),
+            SkipSteadyStateOption.OptionName => new SkipSteadyStateOption(row, database),
 
-            // TODO: Add exception here
+            // TODO: Add exception here "Option Not Recognized"
             _ => new InpOption()
         };
     }

--- a/src/Droplet.Core.Inp/Options/InpOption.cs
+++ b/src/Droplet.Core.Inp/Options/InpOption.cs
@@ -49,5 +49,27 @@ namespace Droplet.Core.Inp.Options
         {
             Database = database;
         }
+
+        /// <summary>
+        /// Create an <see cref="InpOption"/> from the <paramref name="optionName"/>, a <see cref="IInpTableRow"/>,
+        /// and a <see cref="IInpDatabase"/> reference.
+        /// </summary>
+        /// <param name="optionName">The name of the option that will be created</param>
+        /// <param name="database">The <see cref="IInpDatabase"/> that the option will belong to</param>
+        /// <param name="row">The <see cref="IInpTableRow"/> that will be used to build the <see cref="InpOption"/></param>
+        /// <returns>Returns: an option that is refered to by the <paramref name="optionName"/> that is passed</returns>
+        internal static InpOption CreateFromOptionName(string optionName, IInpTableRow row, IInpDatabase database) => optionName switch
+        {
+            FlowUnitsOption.OptionName => new FlowUnitsOption(row: row, database: database),
+            InfiltrationOption.OptionName => new InfiltrationOption(row: row, database: database),
+            FlowRoutingOption.OptionName => new FlowRoutingOption(row: row, database: database),
+            LinkOffsetOption.OptionName => new LinkOffsetOption(row: row, database: database),
+            MinSlopeOption.OptionName => new MinSlopeOption(row: row, database: database),
+            AllowPondingOption.OptionName => new AllowPondingOption(row: row, database: database),
+            SkipSteadyStateOption.OptionName => new SkipSteadyStateOption(row: row, database: database),
+
+            // TODO: Add exception here
+            _ => new InpOption()
+        };
     }
 }

--- a/src/Droplet.Core.Inp/Options/SkipSteadyStateOption.cs
+++ b/src/Droplet.Core.Inp/Options/SkipSteadyStateOption.cs
@@ -1,14 +1,44 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// SkipSteadyStateOption.cs
+// By: Adam Renaud
+// Created: 2019-09-18
+
 using Droplet.Core.Inp.Data;
 
 namespace Droplet.Core.Inp.Options
 {
+    /// <summary>
+    /// The Skip Steady State Option
+    /// </summary>
     public class SkipSteadyStateOption : InpBoolOption
     {
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor that requires a row from an inp file,
+        /// and the database that the option will belong to
+        /// </summary>
+        /// <param name="row">The row that contains the data for the option</param>
+        /// <param name="database">The database that the option belongs to</param>
         public SkipSteadyStateOption(IInpTableRow row, IInpDatabase database) : base(row, database)
         {
         }
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Public override of the Name Property that will
+        /// return the <see cref="OptionName"/> of this class
+        /// </summary>
+        public override string Name => OptionName;
+
+        /// <summary>
+        /// The name of the option in inp files
+        /// </summary>
+        public const string OptionName = "SKIP_STEADY_STATE";
+
+        #endregion
     }
 }

--- a/src/Droplet.Core.Inp/Options/SkipSteadyStateOption.cs
+++ b/src/Droplet.Core.Inp/Options/SkipSteadyStateOption.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Droplet.Core.Inp.Data;
+
+namespace Droplet.Core.Inp.Options
+{
+    public class SkipSteadyStateOption : InpBoolOption
+    {
+        public SkipSteadyStateOption(IInpTableRow row, IInpDatabase database) : base(row, database)
+        {
+        }
+    }
+}

--- a/tests/Droplet.Core.Inp.Tests/FileTestsBase.cs
+++ b/tests/Droplet.Core.Inp.Tests/FileTestsBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Droplet.Core.Inp.IO;
+using System;
 using System.IO;
 using Xunit.Abstractions;
 
@@ -36,6 +37,31 @@ namespace Droplet.Core.Inp.Tests
 
             // Reset the position of the stream
             MemoryStream.Position = 0;
+        }
+
+        /// <summary>
+        /// Set up a parser test. This method will <see cref="Initialize(string)"/>
+        /// the <paramref name="value"/> passed, read the value using an <see cref="InpFileReader"/>,
+        /// parse the file using an <see cref="InpParser"/> and then return the created
+        /// <see cref="InpProject"/>.
+        /// </summary>
+        /// <param name="value">The string that will be parsed</param>
+        protected virtual IInpProject SetupParserTest(string value)
+        {
+            // Initialize the project from the string passed to
+            // this method
+            Initialize(value);
+
+            // Initialize the project, reader and parser
+            var project = new InpProject();
+            var reader = new InpFileReader(MemoryStream);
+            var parser = new InpParser();
+
+            // Parse the file using the above project, reader and parser
+            parser.ParseFile(project, reader);
+
+            // return the project
+            return project;
         }
 
         /// <summary>

--- a/tests/Droplet.Core.Inp.Tests/Options/InpBoolOptionTests.cs
+++ b/tests/Droplet.Core.Inp.Tests/Options/InpBoolOptionTests.cs
@@ -103,16 +103,24 @@ ALLOW_PONDING        NO
         }
 
         /// <summary>
-        /// Test Data for
+        /// Test Data for <see cref="SkipSteadyStateParserTests(string, bool)"/>
+        /// tests
         /// </summary>
         private class SkipSteadyStateParserTestData : IEnumerable<object[]>
         {
+            /// <summary>
+            /// Returns: An inp String and the expected value that
+            /// should be parsed from it
+            /// </summary>
+            /// <returns></returns>
             public IEnumerator<object[]> GetEnumerator()
             {
                 // True
                 yield return new object[]
                 {
-                    @"",
+                    @"[OPTIONS]
+SKIP_STEADY_STATE    YES
+",
 
                     true
                 };
@@ -120,7 +128,9 @@ ALLOW_PONDING        NO
                 // False
                 yield return new object[]
                 {
-                    @"",
+                    @"[OPTIONS]
+SKIP_STEADY_STATE    NO
+",
 
                     false
                 };

--- a/tests/Droplet.Core.Inp.Tests/Options/InpBoolOptionTests.cs
+++ b/tests/Droplet.Core.Inp.Tests/Options/InpBoolOptionTests.cs
@@ -47,18 +47,21 @@ namespace Droplet.Core.Inp.Tests.Options
         [Theory]
         [ClassData(typeof(AllowPondingTestData))]
         public void AllowPondingTests(string value, bool expectedValue)
-        {
-            Initialize(value);
-            var project = new InpProject();
-            var parser = new InpParser();
-            var reader = new InpFileReader(MemoryStream);
-            parser.ParseFile(project, reader);
+            => Assert
+                .Equal(expectedValue, 
+                SetupParserTest(value).Database.GetOption<AllowPondingOption>().Value);
 
-            var option = project.Database.GetOption<AllowPondingOption>();
-
-            Assert.Equal(expectedValue, option.Value);
-        }
-
+        /// <summary>
+        /// Testing the parsing of the <see cref="SkipSteadyStateOption"/>
+        /// </summary>
+        /// <param name="value">A string from an inp file</param>
+        /// <param name="expectedValue">The expected option</param>
+        [Theory]
+        [ClassData(typeof(SkipSteadyStateParserTestData))]
+        public void SkipSteadyStateParserTests(string value, bool expectedValue)
+            => Assert
+            .Equal(expectedValue,
+                SetupParserTest(value).Database.GetOption<SkipSteadyStateOption>().Value);
 
         #endregion  
 
@@ -91,6 +94,33 @@ ALLOW_PONDING        YES
                     @"[OPTIONS]
 ALLOW_PONDING        NO
 ",
+
+                    false
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        /// <summary>
+        /// Test Data for
+        /// </summary>
+        private class SkipSteadyStateParserTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                // True
+                yield return new object[]
+                {
+                    @"",
+
+                    true
+                };
+
+                // False
+                yield return new object[]
+                {
+                    @"",
 
                     false
                 };


### PR DESCRIPTION
Adding the `SkipSteadyStateOption` and associated tests. Also, refactored some code and placed the `CreateFromOptionName` method that was formerly the `GetInpOptionEntity` into the `InpOption` class.