### PR TITLE
Adding the Sweeping Start DateTime Option and associated tests

### DIFF
--- a/src/Droplet.Core.Inp/Options/InpOption.cs
+++ b/src/Droplet.Core.Inp/Options/InpOption.cs
@@ -87,6 +87,9 @@ namespace Droplet.Core.Inp.Options
             EndDateTimeOption.TimeOptionName => database.GetOption<EndDateTimeOption>()
                                                         ?.AddTime(TimeSpan.Parse(row[1])),
 
+            // Sweeping Start Option
+            SweepingStartDateTimeOption.OptionName => new SweepingStartDateTimeOption(row, database),
+
             // TODO: Add exception here "Option Not Recognized"
             _ => new InpOption()
         };

--- a/src/Droplet.Core.Inp/Options/InpOption.cs
+++ b/src/Droplet.Core.Inp/Options/InpOption.cs
@@ -87,8 +87,9 @@ namespace Droplet.Core.Inp.Options
             EndDateTimeOption.TimeOptionName => database.GetOption<EndDateTimeOption>()
                                                         ?.AddTime(TimeSpan.Parse(row[1])),
 
-            // Sweeping Start Option
+            // Sweeping Start & End Options
             SweepingStartDateTimeOption.OptionName => new SweepingStartDateTimeOption(row, database),
+            SweepingEndDateTimeOption.OptionName => new SweepingEndDateTimeOption(row, database),
 
             // TODO: Add exception here "Option Not Recognized"
             _ => new InpOption()

--- a/src/Droplet.Core.Inp/Options/SweepingEndDateTimeOption.cs
+++ b/src/Droplet.Core.Inp/Options/SweepingEndDateTimeOption.cs
@@ -1,0 +1,30 @@
+﻿// SweepingEndDateTimeOption.cs
+// By: Adam Renaud
+// Created: 2019-09-22
+
+using Droplet.Core.Inp.Data;
+
+namespace Droplet.Core.Inp.Options
+{
+    /// <summary>
+    /// The end date for steet sweeping option
+    /// </summary>
+    public class SweepingEndDateTimeOption : InpDateTimeOption
+    {
+        /// <summary>
+        /// Constructor that accepts an <see cref="IInpTableRow"/> 
+        /// and an <see cref="IInpDatabase"/>.
+        /// </summary>
+        /// <param name="row">The row that will be used to construct the option</param>
+        /// <param name="database">The database that the option will belong to</param>
+        public SweepingEndDateTimeOption(IInpTableRow row, IInpDatabase database) : base(row, database)
+        {
+        }
+
+        /// <summary>
+        /// The option name for the <see cref="SweepingEndDateTimeOption"/> 
+        /// in inp files
+        /// </summary>
+        internal const string OptionName = "SWEEP_END";
+    }
+}

--- a/src/Droplet.Core.Inp/Options/SweepingStartDateTimeOption.cs
+++ b/src/Droplet.Core.Inp/Options/SweepingStartDateTimeOption.cs
@@ -1,0 +1,31 @@
+﻿// SweepingStartDateTimeOption.cs
+// By: Adam Renaud
+// Created: 2019-09-21
+
+using Droplet.Core.Inp.Data;
+
+namespace Droplet.Core.Inp.Options
+{
+    /// <summary>
+    /// The starting time for street sweeping
+    /// </summary>
+    public class SweepingStartDateTimeOption : InpDateTimeOption
+    {
+        /// <summary>
+        /// Constructor that accepts an <see cref="IInpTableRow"/> 
+        /// and an <see cref="IInpDatabase"/>
+        /// </summary>
+        /// <param name="row">The row that will be used to construct the
+        ///  option</param>
+        /// <param name="database">The database that the option will belong to</param>
+        public SweepingStartDateTimeOption(IInpTableRow row, IInpDatabase database) : base(row, database)
+        {
+            // Construction will happen in the base class
+        }
+
+        /// <summary>
+        /// The name of the date option in an inp file
+        /// </summary>
+        internal const string OptionName = "SWEEP_START";
+    }
+}

--- a/tests/Droplet.Core.Inp.Tests/Options/InpDateTimeOptionTests.cs
+++ b/tests/Droplet.Core.Inp.Tests/Options/InpDateTimeOptionTests.cs
@@ -55,6 +55,45 @@ namespace Droplet.Core.Inp.Tests.Options
         public void StartDateTimeParserTests_WithoutStartDate(string value)
             => Assert.Throws<InpParseException>(() => SetupParserTest(value));
 
+        /// <summary>
+        /// Test Data for the <see cref="StartDateTimeParserTests(string, DateTime)"/> tests
+        /// </summary>
+        private class StartDateTimeParserTestData : IEnumerable<object[]>
+        {
+
+            /// <summary>
+            /// A string from an inp file
+            /// and the expected <see cref="DateTime"/> that the
+            /// parser should create
+            /// </summary>
+            /// <returns></returns>
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                // With start time
+                yield return new object[]
+                {
+                    @"[OPTIONS]
+START_DATE           07/28/2019
+START_TIME           01:12:50
+",
+
+                    new DateTime(2019, 07, 28, 1, 12, 50)
+                };
+
+                // Without start time
+                yield return new object[]
+{
+                    @"[OPTIONS]
+START_DATE           07/28/2019
+",
+
+                    new DateTime(2019, 07, 28, 0, 0, 0)
+};
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
         #endregion
 
         #region Report StartDate Time Tests
@@ -72,6 +111,33 @@ namespace Droplet.Core.Inp.Tests.Options
         public void ReportStartDateTimeParserTests(string value, DateTime expectedValue)
             => Assert.Equal(expectedValue,
                 SetupParserTest(value).Database.GetOption<ReportStartDateTimeOption>().Value);
+
+        /// <summary>
+        /// Test Data for the <see cref="ReportStartDateTimeParserTests(string, DateTime)"/> tests
+        /// </summary>
+        private class ReportStartDateTimeParserTestData : IEnumerable<object[]>
+        {
+            /// <summary>
+            /// Returns the <see cref="string"/> and expected <see cref="DateTime"/>
+            ///  for the test
+            /// </summary>
+            /// <returns>Returns: a string and a DateTime for the test</returns>
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[]
+                {
+                    @"[OPTIONS]
+REPORT_START_DATE    07/28/2019
+REPORT_START_TIME    00:00:00
+",
+
+                    new DateTime(2019, 07, 28, 0, 0, 0)
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
 
         #endregion
 
@@ -147,69 +213,34 @@ SWEEP_START          01/01
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
 
-        #endregion
-
-        #region Test Data
+        /// <summary>
+        /// Testing the parsing of the <see cref="SweepingEndDateTimeOption"/> 
+        /// </summary>
+        /// <param name="value">A <see cref="string"/> from an inp file that
+        /// contains a <see cref="SweepingEndDateTimeOption"/> that will be parsed</param>
+        /// <param name="expectedValue">The expected <see cref="DateTime"/> that the parser should 
+        /// produced from the <paramref name="value"/></param>
+        [Theory]
+        [ClassData(typeof(SweepingEndDateTimeParserTestData))]
+        public void SweepingEndDateTimeParserTests(string value, DateTime expectedValue)
+            => Assert.Equal(expectedValue, SetupParserTest(value).Database
+                                                                 .GetOption<SweepingEndDateTimeOption>().Value);
 
         /// <summary>
-        /// Test Data for the <see cref="StartDateTimeParserTests(string, DateTime)"/> tests
+        /// Test data for the <see cref="SweepingEndDateTimeParserTests(string, DateTime)"/> 
+        /// tests
         /// </summary>
-        private class StartDateTimeParserTestData : IEnumerable<object[]>
+        private class SweepingEndDateTimeParserTestData : IEnumerable<object[]>
         {
-
-            /// <summary>
-            /// A string from an inp file
-            /// and the expected <see cref="DateTime"/> that the
-            /// parser should create
-            /// </summary>
-            /// <returns></returns>
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                // With start time
-                yield return new object[]
-                {
-                    @"[OPTIONS]
-START_DATE           07/28/2019
-START_TIME           01:12:50
-",
-
-                    new DateTime(2019, 07, 28, 1, 12, 50)
-                };
-
-                // Without start time
-                yield return new object[]
-{
-                    @"[OPTIONS]
-START_DATE           07/28/2019
-",
-
-                    new DateTime(2019, 07, 28, 0, 0, 0)
-};
-            }
-
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        /// <summary>
-        /// Test Data for the <see cref="ReportStartDateTimeParserTests(string, DateTime)"/> tests
-        /// </summary>
-        private class ReportStartDateTimeParserTestData : IEnumerable<object[]>
-        {
-            /// <summary>
-            /// Returns the <see cref="string"/> and expected <see cref="DateTime"/>
-            ///  for the test
-            /// </summary>
-            /// <returns>Returns: a string and a DateTime for the test</returns>
             public IEnumerator<object[]> GetEnumerator()
             {
                 yield return new object[]
                 {
                     @"[OPTIONS]
-REPORT_START_DATE    07/28/2019
-REPORT_START_TIME    00:00:00
+SWEEP_END            12/31
 ",
 
-                    new DateTime(2019, 07, 28, 0, 0, 0)
+                    new DateTime(DateTime.Now.Year, 12, 31)
                 };
             }
 
@@ -217,5 +248,6 @@ REPORT_START_TIME    00:00:00
         }
 
         #endregion
+
     }
 }

--- a/tests/Droplet.Core.Inp.Tests/Options/InpDateTimeOptionTests.cs
+++ b/tests/Droplet.Core.Inp.Tests/Options/InpDateTimeOptionTests.cs
@@ -111,6 +111,44 @@ END_TIME             06:00:00
 
         #endregion
 
+        #region Sweeping Date Time Tests
+
+        /// <summary>
+        /// Testing the parsing of the <see cref="SweepingStartDateTimeOption"/> 
+        /// Option
+        /// </summary>
+        /// <param name="value">A string from an inp file that contains the option</param>
+        /// <param name="expectedValue">The expected value from the option</param>
+        [Theory]
+        [ClassData(typeof(SweepingStartDateTimeParserTestData))]
+        public void SweepingStartDateTimeParserTests(string value, DateTime expectedValue)
+            => Assert.Equal(expectedValue, SetupParserTest(value)
+                .Database
+                .GetOption<SweepingStartDateTimeOption>().Value);
+
+        /// <summary>
+        /// Test data for the <see cref="SweepingStartDateTimeParserTests(string, DateTime)"/>
+        ///  tests
+        /// </summary>
+        private class SweepingStartDateTimeParserTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[]
+                {
+                    @"[OPTIONS]
+SWEEP_START          01/01
+",
+
+                    new DateTime(DateTime.Now.Year, 1, 1)
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        #endregion
+
         #region Test Data
 
         /// <summary>


### PR DESCRIPTION
Addressing #14. Added the `SweepingStartDateTimeOption` and associated tests.

Still need to add `SweepingEndDateTimeOption` and associated tests.