### PR TITLE
Adding the Head Tolerance Option and associated tests

### DIFF
--- a/src/Droplet.Core.Inp/Options/HeadToleranceOption.cs
+++ b/src/Droplet.Core.Inp/Options/HeadToleranceOption.cs
@@ -1,0 +1,40 @@
+﻿using Droplet.Core.Inp.Data;
+
+namespace Droplet.Core.Inp.Options
+{
+    /// <summary>
+    /// The head tolerance option
+    /// </summary>
+    public class HeadToleranceOption : InpDoubleOption
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Default constructor for the <see cref="HeadToleranceOption"/> that accept 
+        /// a <see cref="double"/> that will be used to set the value of this option.
+        /// </summary>
+        /// <param name="value">The value that this option's value will be set to</param>
+        public HeadToleranceOption(double value) : base(value) => Name = OptionName;
+
+        /// <summary>
+        /// Internal constructor that accepts an <see cref="IInpTableRow"/> that will be parsed and 
+        /// an <see cref="IInpDatabase"/> that the option will belong to.
+        /// </summary>
+        /// <param name="row">The row that will set the value of this option</param>
+        /// <param name="database">The database that this option will belong to</param>
+        internal HeadToleranceOption(IInpTableRow row, IInpDatabase database) : base(row, database)
+        {
+        }
+
+        #endregion
+
+        #region Internal Members
+
+        /// <summary>
+        /// The inp Option Name for this option
+        /// </summary>
+        internal const string OptionName = "HEAD_TOLERANCE";
+
+        #endregion
+    }
+}

--- a/src/Droplet.Core.Inp/Options/InpOption.cs
+++ b/src/Droplet.Core.Inp/Options/InpOption.cs
@@ -165,6 +165,9 @@ namespace Droplet.Core.Inp.Options
             // Max trials option
             MaxTrialsOption.OptionName => new MaxTrialsOption(row, database),
 
+            // Head Tolerance option
+            HeadToleranceOption.OptionName => new HeadToleranceOption(row, database),
+
             // TODO: Add exception here "Option Not Recognized"
             _ => new InpOption()
         };

--- a/tests/Droplet.Core.Inp.Tests/Options/InpDoubleOptionTests.cs
+++ b/tests/Droplet.Core.Inp.Tests/Options/InpDoubleOptionTests.cs
@@ -1,4 +1,6 @@
-﻿using Droplet.Core.Inp.Options;
+﻿using Droplet.Core.Inp.Entities;
+using Droplet.Core.Inp.Exceptions;
+using Droplet.Core.Inp.Options;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -77,6 +79,53 @@ MIN_SURFAREA         1.167
         [InlineData(MinSurfaceAreaValidString, 1.167)]
         public void MinSurfaceAreaToInpStringTest(string inpString, double value)
             => Assert.Equal(PruneInpString(inpString, OptionsHeader), new MinSurfaceAreaOption(value).ToInpString());
+
+        #endregion
+
+        #region Head Tolerance Tests
+
+        /// <summary>
+        /// Valid string for the <see cref="HeadToleranceOption"/>
+        /// </summary>
+        private const string HeadTolerance_ValidString = @"[OPTIONS]
+HEAD_TOLERANCE       0.0015";
+
+        /// <summary>
+        /// Invalid string for the <see cref="HeadToleranceOption"/>
+        /// </summary>
+        private const string HeadTolderance_InvalidString = @"[OPTIONS]
+HEAD_TOLERANCE       INVALIDSTRING
+";
+
+        /// <summary>
+        /// Testing the parsing of <see cref="HeadToleranceOption"/> with a valid <see cref="string"/>
+        /// </summary>
+        /// <param name="inpString">The valid string that contains the <see cref="HeadToleranceOption"/></param>
+        /// <param name="value">The value that is expected from the parser</param>
+        [Theory]
+        [InlineData(HeadTolerance_ValidString, 0.0015)]
+        public void HeadToleranceParser_ValidString_ShouldMatchValue(string inpString, double value)
+            => Assert.Equal(value, SetupProject(inpString).Database.GetOption<HeadToleranceOption>().Value);
+
+        /// <summary>
+        /// Testing the parsing of <see cref="HeadToleranceOption"/> with an invalid string.
+        /// </summary>
+        /// <param name="inpString">The invalid string</param>
+        [Theory]
+        [InlineData(HeadTolderance_InvalidString)]
+        public void HeadToleranceParser_InvalidString_ShouldThrowInpFileException(string inpString)
+            => Assert.Throws<InpFileException>(() => SetupProject(inpString));
+
+        /// <summary>
+        /// Testing the <see cref="IInpEntity.ToInpString"/> method as overridden for the 
+        /// <see cref="HeadToleranceOption"/>
+        /// </summary>
+        /// <param name="expected">The expected <see cref="string"/></param>
+        /// <param name="value">The value that will create a new <see cref="HeadToleranceOption"/></param>
+        [Theory]
+        [InlineData(HeadTolerance_ValidString, 0.0015)]
+        public void HeadTolerance_ToInpString_ShouldMatchExpected(string expected, double value)
+            => Assert.Equal(PruneInpString(expected, OptionsHeader), new HeadToleranceOption(value).ToInpString());
 
         #endregion
     }


### PR DESCRIPTION
Adding the `HeadToleranceOption` and associated tests. Addressed #36 